### PR TITLE
Remove stray left angle bracket from the navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,7 +6,7 @@
 
 <nav class="navbar navbar-default">
   <div class="container-fluid">
-    <div class="navbar-header"><
+    <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>


### PR DESCRIPTION
Not tested, but I think it works. The branch and commit names have a typo in them---they should say 'left angle backet' instead of 'caret'.

(The stray left angle bracket shows in the navbar.)